### PR TITLE
Debug websocket and api connection errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
   <meta name="description" content="Web site created using create-react-app" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="manifest" href="/manifest.json" />
-<script type="module" src="https://static.rocket.new/rocket-web.js?_cfg=https%3A%2F%2Fgoogleads4701back.builtwithrocket.new&_be=https%3A%2F%2Fapplication.rocket.new&_v=0.1.6"></script>
+  <!-- Script do Rocket temporariamente desabilitado para resolver problemas de WebSocket -->
+  <!-- <script type="module" src="https://static.rocket.new/rocket-web.js?_cfg=https%3A%2F%2Fgoogleads4701back.builtwithrocket.new&_be=https%3A%2F%2Fapplication.rocket.new&_v=0.1.6"></script> -->
 </head>
 
 <body>

--- a/src/services/umblerService.js
+++ b/src/services/umblerService.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 
 // Configuração base da API
-const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001/api/umbler';
+const API_BASE_URL = '/api/umbler';
 
 class UmblerService {
   constructor() {
@@ -19,12 +19,14 @@ class UmblerService {
       (response) => response,
       (error) => {
         console.error('Erro na API Umbler:', error);
-        throw this.handleError(error);
+        // Não lançar erro novamente, apenas retornar o erro tratado
+        return Promise.reject(this.handleError(error));
       }
     );
   }
 
   handleError(error) {
+    console.log('Error details:', error);
     if (error.response) {
       // Erro da API
       return {
@@ -232,7 +234,12 @@ class UmblerService {
       });
       return { ...response.data, connected: true };
     } catch (error) {
-      return { connected: false, error: error.message };
+      console.log('Health check failed:', error);
+      return { 
+        connected: false, 
+        error: error.message || 'Erro de conexão',
+        status: 'error'
+      };
     }
   }
 
@@ -257,11 +264,13 @@ class UmblerService {
       return response.data;
     } catch (error) {
       console.error('Erro ao buscar estatísticas:', error);
+      // Retornar dados padrão em caso de erro
       return {
         totalContacts: 0,
         totalMessages: 0,
         totalConversations: 0,
-        openConversations: 0
+        openConversations: 0,
+        error: error.message || 'Erro de conexão'
       };
     }
   }
@@ -277,6 +286,7 @@ class UmblerService {
       return contactsResponse.contacts || [];
     } catch (error) {
       console.error('Erro ao buscar contatos com última mensagem:', error);
+      // Retornar array vazio em caso de erro
       return [];
     }
   }
@@ -293,6 +303,7 @@ class UmblerService {
       return response.messages || [];
     } catch (error) {
       console.error('Erro ao buscar mensagens da conversa:', error);
+      // Retornar array vazio em caso de erro
       return [];
     }
   }
@@ -316,7 +327,11 @@ class UmblerService {
         });
       } catch (error) {
         console.error('Erro no polling:', error);
-        callback({ error: error.message });
+        callback({ 
+          error: error.message || 'Erro de conexão',
+          stats: { totalContacts: 0, totalMessages: 0, totalConversations: 0, openConversations: 0 },
+          contacts: []
+        });
       }
     };
 

--- a/src/services/umblerService.js
+++ b/src/services/umblerService.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 
 // Configuração base da API
-const API_BASE_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3001/api/umbler';
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001/api/umbler';
 
 class UmblerService {
   constructor() {

--- a/src/utils/apiClient.js
+++ b/src/utils/apiClient.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+const API_BASE_URL = '/api';
 
 class ApiClient {
   constructor() {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,17 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Configure Vite proxy and enhance API error handling to resolve connection and WebSocket issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application was experiencing `ERR_CONNECTION_REFUSED` and `WebSocket` connection failures due to incorrect API base URLs and a conflicting third-party script. This PR addresses these by:
1.  Setting up a proxy in `vite.config.js` to correctly route `/api` requests to the backend.
2.  Updating `umblerService.js` and `apiClient.js` to use relative API paths, leveraging the new proxy.
3.  Improving error handling in `umblerService.js` to provide more robust behavior when backend connections fail.
4.  Temporarily disabling the Rocket script in `index.html` which was causing WebSocket connection errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-49983f8b-145b-4687-8a6f-5da6954e1f39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49983f8b-145b-4687-8a6f-5da6954e1f39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>